### PR TITLE
Fixes for Blender 4.0 API changes

### DIFF
--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "3D Gaussian Splatting",
     "author": "Alex Carlier",
     "version": (0, 0, 1),
-    "blender": (3, 4, 0),
+    "blender": (4, 0, 0),
     "location": "3D Viewport > Sidebar > 3D Gaussian Splatting",
     "description": "3D Gaussian Splatting tool",
 }


### PR DESCRIPTION
This fixes the issues with changes in the Blender API.

Specifically the naming of Principled Shader Node parameters as well as the new naming convention fore creating node groups.

I have also added a check for plydata.elements[0]["opacity"] as the opacity seems to be missing in Splats from LumaAI