### PR TITLE
opacity filtering functionality

### DIFF
--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -1185,10 +1185,6 @@ class GaussianSplattingPanel(bpy.types.Panel):
                 row.prop(obj.modifiers["Geometry Nodes"].node_group.nodes.get("Random Value").inputs["Probability"],
                          "default_value", text="Display Percentage")
 
-            # Select active operator
-            row = layout.row()
-            row.operator()
-
             # Export Gaussian Splatting button
             row = layout.row()
             row.operator(ExportGaussianSplatting.bl_idname, text="Export Gaussian Splatting")

--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "3D Gaussian Splatting",
     "author": "Alex Carlier",
     "version": (0, 0, 1),
-    "blender": (3, 4, 0),
+    "blender": (4, 0, 0),
     "location": "3D Viewport > Sidebar > 3D Gaussian Splatting",
     "description": "3D Gaussian Splatting tool",
 }
@@ -16,13 +16,12 @@ import random
 from .plyfile import PlyData, PlyElement
 
 
-
 class ImportGaussianSplatting(bpy.types.Operator):
     bl_idname = "object.import_gaussian_splatting"
     bl_label = "Import Gaussian Splatting"
     bl_description = "Import a 3D Gaussian Splatting file into the scene"
     bl_options = {"REGISTER", "UNDO"}
-    
+
     filepath: bpy.props.StringProperty(
         name="File Path",
         description="Path to the Gaussian Splatting file",
@@ -35,7 +34,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
             return {'CANCELLED'}
 
         start_time_0 = time.time()
-        
+
         bpy.context.scene.render.engine = 'CYCLES'
 
         if context.preferences.addons["cycles"].preferences.has_active_device():
@@ -60,11 +59,15 @@ class ImportGaussianSplatting(bpy.types.Operator):
         xyz = np.stack((np.asarray(plydata.elements[0]["x"]),
                         np.asarray(plydata.elements[0]["y"]),
                         np.asarray(plydata.elements[0]["z"])), axis=1)
-    
+
         N = len(xyz)
-        
-        log_opacities = np.asarray(plydata.elements[0]["opacity"])[..., np.newaxis]
-        opacities = 1 / (1 + np.exp(-log_opacities))
+        print(f"ply data: {plydata.elements[0]}")
+        if 'opacity' in plydata.elements[0]:
+            log_opacities = np.asarray(plydata.elements[0]["opacity"])[..., np.newaxis]
+            opacities = 1 / (1 + np.exp(-log_opacities))
+        else:
+            log_opacities = np.asarray(1)[..., np.newaxis]
+            opacities = 1 / (1 + np.exp(-log_opacities))
 
         features_dc = np.zeros((N, 3, 1))
         features_dc[:, 0, 0] = np.asarray(plydata.elements[0]["f_dc_0"])
@@ -72,19 +75,19 @@ class ImportGaussianSplatting(bpy.types.Operator):
         features_dc[:, 2, 0] = np.asarray(plydata.elements[0]["f_dc_2"])
 
         extra_f_names = [p.name for p in plydata.elements[0].properties if p.name.startswith("f_rest_")]
-        extra_f_names = sorted(extra_f_names, key = lambda x: int(x.split('_')[-1]))
-        
+        extra_f_names = sorted(extra_f_names, key=lambda x: int(x.split('_')[-1]))
+
         features_extra = np.zeros((N, len(extra_f_names)))
         for idx, attr_name in enumerate(extra_f_names):
             features_extra[:, idx] = np.asarray(plydata.elements[0][attr_name])
         features_extra = features_extra.reshape((N, 3, 15))
 
         log_scales = np.stack((np.asarray(plydata.elements[0]["scale_0"]),
-                           np.asarray(plydata.elements[0]["scale_1"]),
-                           np.asarray(plydata.elements[0]["scale_2"])), axis=1)
+                               np.asarray(plydata.elements[0]["scale_1"]),
+                               np.asarray(plydata.elements[0]["scale_2"])), axis=1)
 
         scales = np.exp(log_scales)
-        
+
         quats = np.stack((np.asarray(plydata.elements[0]["rot_0"]),
                           np.asarray(plydata.elements[0]["rot_1"]),
                           np.asarray(plydata.elements[0]["rot_2"]),
@@ -96,7 +99,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
             quat = mathutils.Quaternion(quats[i].tolist())
             euler = quat.to_euler()
             rots_euler[i] = (euler.x, euler.y, euler.z)
-        
+
         print("Data loaded in", time.time() - start_time, "seconds")
 
         ##############################
@@ -124,17 +127,17 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         logscale_attr = mesh.attributes.new(name="logscale", type='FLOAT_VECTOR', domain='POINT')
         logscale_attr.data.foreach_set("vector", log_scales.flatten())
-        
+
         sh0_attr = mesh.attributes.new(name="sh0", type='FLOAT_VECTOR', domain='POINT')
         sh0_attr.data.foreach_set("vector", features_dc.flatten())
-        
+
         for j in range(0, 15):
-            sh_attr = mesh.attributes.new(name=f"sh{j+1}", type='FLOAT_VECTOR', domain='POINT')
+            sh_attr = mesh.attributes.new(name=f"sh{j + 1}", type='FLOAT_VECTOR', domain='POINT')
             sh_attr.data.foreach_set("vector", features_extra[:, :, j].flatten())
 
         rot_quatxyz_attr = mesh.attributes.new(name="quatxyz", type='FLOAT_VECTOR', domain='POINT')
         rot_quatxyz_attr.data.foreach_set("vector", quats[:, :3].flatten())
-        
+
         rot_quatw_attr = mesh.attributes.new(name="quatw", type='FLOAT', domain='POINT')
         rot_quatw_attr.data.foreach_set("value", quats[:, 3].flatten())
 
@@ -153,7 +156,6 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         print("Mesh attributes added in", time.time() - start_time, "seconds")
 
-
         ##############################
         # Materials
         ##############################
@@ -168,7 +170,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         for node in mat_tree.nodes:
             mat_tree.nodes.remove(node)
-        
+
         sh_attr_nodes = []
         sh_inst_attr_nodes = []  # ellipsoids
         sh_geom_attr_nodes = []  # point cloud
@@ -179,7 +181,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
             sh_inst_attr_node.attribute_name = f"sh{j}"
             sh_inst_attr_node.attribute_type = 'INSTANCER'
             sh_inst_attr_nodes.append(sh_inst_attr_node)
-            
+
             sh_geom_attr_node = mat_tree.nodes.new('ShaderNodeAttribute')
             sh_geom_attr_node.location = (1800, 200 * j)
             sh_geom_attr_node.attribute_name = f"sh{j}"
@@ -236,8 +238,9 @@ class ImportGaussianSplatting(bpy.types.Operator):
         principled_node = mat_tree.nodes.new('ShaderNodeBsdfPrincipled')
         principled_node.location = (3200, 600)
         principled_node.inputs["Base Color"].default_value = (0, 0, 0, 1)
-        principled_node.inputs["Specular"].default_value = 0
+        principled_node.inputs["Specular IOR Level"].default_value = 0
         principled_node.inputs["Roughness"].default_value = 0
+        principled_node.inputs["Emission Strength"].default_value = 1
 
         output_node = mat_tree.nodes.new('ShaderNodeOutputMaterial')
         output_node.location = (3600, 0)
@@ -320,7 +323,6 @@ class ImportGaussianSplatting(bpy.types.Operator):
             multiply_node.inputs[0]
         )
 
-
         # SH Coefficients
 
         C0 = 0.28209479177387814
@@ -396,7 +398,6 @@ class ImportGaussianSplatting(bpy.types.Operator):
         mat_tree.links.new(y, xz_node.inputs[1])
         xz = xz_node.outputs["Value"]
 
-
         # SH 0
 
         scale_node_0 = mat_tree.nodes.new('ShaderNodeVectorMath')
@@ -460,7 +461,6 @@ class ImportGaussianSplatting(bpy.types.Operator):
             math_node.outputs["Value"],
             scale_node_2.inputs["Scale"]
         )
-
 
         # SH 3
 
@@ -712,12 +712,13 @@ class ImportGaussianSplatting(bpy.types.Operator):
         scale_node_15.operation = 'SCALE'
         scale_node_15.location = (2400, 3200)
 
-
         # Result
 
         res_nodes = [
-            scale_node_0, scale_node_1, scale_node_2, scale_node_3, scale_node_4, scale_node_5, scale_node_6, scale_node_7,
-            scale_node_8, scale_node_9, scale_node_10, scale_node_11, scale_node_12, scale_node_13, scale_node_14, scale_node_15
+            scale_node_0, scale_node_1, scale_node_2, scale_node_3, scale_node_4, scale_node_5, scale_node_6,
+            scale_node_7,
+            scale_node_8, scale_node_9, scale_node_10, scale_node_11, scale_node_12, scale_node_13, scale_node_14,
+            scale_node_15
         ]
 
         add_node = mat_tree.nodes.new('ShaderNodeVectorMath')
@@ -772,9 +773,8 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         mat_tree.links.new(
             gamma_node.outputs["Color"],
-            principled_node.inputs["Emission"]
+            principled_node.inputs["Emission Color"],
         )
-
 
         geometry_node = mat_tree.nodes.new('ShaderNodeNewGeometry')
         geometry_node.location = (2600, 0)
@@ -792,7 +792,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
             geometry_node.outputs["Incoming"],
             vector_math_node.inputs[1]
         )
-        
+
         math_node = mat_tree.nodes.new('ShaderNodeMath')
         math_node.operation = 'MULTIPLY'
         math_node.location = (3000, 0)
@@ -827,16 +827,18 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         start_time = time.time()
 
-        geo_node_mod = obj.modifiers.new(name="GeometryNodes", type='NODES')
+        geo_node_mod = obj.modifiers.new(name="Geometry Nodes", type='NODES')
 
         geo_tree = bpy.data.node_groups.new(name="GaussianSplatting", type='GeometryNodeTree')
         geo_node_mod.node_group = geo_tree
 
         for node in geo_tree.nodes:
             geo_tree.nodes.remove(node)
-        
-        geo_tree.inputs.new('NodeSocketGeometry', "Geometry")
-        geo_tree.outputs.new('NodeSocketGeometry', "Geometry")
+
+        # geo_tree.inputs.new('NodeSocketGeometry', "Geometry")
+        # geo_tree.outputs.new('NodeSocketGeometry', "Geometry")
+        geo_tree.interface.new_socket(name='Geometry', in_out='INPUT', socket_type='NodeSocketGeometry')
+        geo_tree.interface.new_socket(name='Geometry', in_out='OUTPUT', socket_type='NodeSocketGeometry')
 
         group_input_node = geo_tree.nodes.new('NodeGroupInput')
         group_input_node.location = (0, 0)
@@ -845,10 +847,31 @@ class ImportGaussianSplatting(bpy.types.Operator):
         mesh_to_points_node.location = (200, 0)
         mesh_to_points_node.inputs["Radius"].default_value = 0.01
 
+        # Opacity thresholding
+
+        opacity_attr_gn_node = geo_tree.nodes.new('GeometryNodeInputNamedAttribute')
+        opacity_attr_gn_node.location = (100, 100)
+        opacity_attr_gn_node.data_type = 'FLOAT'
+        opacity_attr_gn_node.inputs["Name"].default_value = "opacity"
+
+        threshold_value_node = geo_tree.nodes.new('ShaderNodeValue')
+        threshold_value_node.location = (250, 100)
+
+        threshold_node = geo_tree.nodes.new('ShaderNodeMath')
+        threshold_node.location = (200, 100)
+        threshold_node.operation = 'GREATER_THAN'
+
+        join_selection_node = geo_tree.nodes.new('FunctionNodeBooleanMath')
+        join_selection_node.location = (300, 100)
+        join_selection_node.operation = 'AND'
+
         random_value_node = geo_tree.nodes.new('FunctionNodeRandomValue')
         random_value_node.location = (0, 400)
-        random_value_node.inputs["Probability"].default_value = min(RECOMMENDED_MAX_GAUSSIANS / N, 1)
         random_value_node.data_type = 'BOOLEAN'
+        if "Probability" in random_value_node.inputs:
+            random_value_node.inputs["Probability"].default_value = min(RECOMMENDED_MAX_GAUSSIANS / N, 1)
+        else:
+            print("Error: 'Probability' input not found on 'FunctionNodeRandomValue'")
 
         maximum_node = geo_tree.nodes.new('ShaderNodeMath')
         maximum_node.location = (0, 400)
@@ -902,7 +925,27 @@ class ImportGaussianSplatting(bpy.types.Operator):
         )
 
         geo_tree.links.new(
+            opacity_attr_gn_node.outputs["Attribute"],
+            threshold_node.inputs[0]
+        )
+
+        geo_tree.links.new(
+            threshold_value_node.outputs[0],
+            threshold_node.inputs[1]
+        )
+
+        geo_tree.links.new(
+            threshold_node.outputs[0],
+            join_selection_node.inputs[0]
+        )
+
+        geo_tree.links.new(
             maximum_node.outputs["Value"],
+            join_selection_node.inputs[1]
+        )
+
+        geo_tree.links.new(
+            join_selection_node.outputs[0],
             mesh_to_points_node.inputs["Selection"]
         )
 
@@ -950,7 +993,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
             set_material_node.outputs["Geometry"],
             realize_instances_node.inputs["Geometry"]
         )
-        
+
         geo_tree.links.new(
             realize_instances_node.outputs["Geometry"],
             group_output_node.inputs["Geometry"]
@@ -969,7 +1012,7 @@ class ImportGaussianSplatting(bpy.types.Operator):
 
         avg_node = geo_tree.nodes.new('ShaderNodeVectorMath')
         avg_node.operation = 'DOT_PRODUCT'
-        avg_node.inputs[1].default_value = (1/3, 1/3, 1/3)
+        avg_node.inputs[1].default_value = (1 / 3, 1 / 3, 1 / 3)
 
         geo_tree.links.new(
             scale_attr.outputs["Attribute"],
@@ -1011,30 +1054,31 @@ class ImportGaussianSplatting(bpy.types.Operator):
     def invoke(self, context, event):
         if not self.filepath:
             self.filepath = bpy.path.abspath("//point_cloud.ply")
-        
+
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 
 
 def construct_list_of_attributes():
-        l = ['x', 'y', 'z', 'nx', 'ny', 'nz']
-        # All channels except the 3 DC
-        for i in range(3):
-            l.append('f_dc_{}'.format(i))
-        for i in range(45):
-            l.append('f_rest_{}'.format(i))
-        l.append('opacity')
-        for i in range(3):
-            l.append('scale_{}'.format(i))
-        for i in range(4):
-            l.append('rot_{}'.format(i))
-        return l
+    l = ['x', 'y', 'z', 'nx', 'ny', 'nz']
+    # All channels except the 3 DC
+    for i in range(3):
+        l.append('f_dc_{}'.format(i))
+    for i in range(45):
+        l.append('f_rest_{}'.format(i))
+    l.append('opacity')
+    for i in range(3):
+        l.append('scale_{}'.format(i))
+    for i in range(4):
+        l.append('rot_{}'.format(i))
+    return l
+
 
 class ExportGaussianSplatting(bpy.types.Operator):
     bl_idname = "object.export_gaussian_splatting"
     bl_label = "Export 3D Gaussian Splatting"
     bl_description = "Export a 3D Gaussian Splatting to file"
-    
+
     filepath: bpy.props.StringProperty(
         name="File Path",
         description="Path to the Gaussian Splatting file",
@@ -1054,7 +1098,7 @@ class ExportGaussianSplatting(bpy.types.Operator):
         mesh: bpy.types.Mesh = obj.data
 
         N = len(mesh.vertices)
-        
+
         xyz = np.zeros((N, 3))
         normals = np.zeros((N, 3))
         f_dc = np.zeros((N, 3))
@@ -1067,7 +1111,7 @@ class ExportGaussianSplatting(bpy.types.Operator):
         log_opacity_attr = mesh.attributes.get("log_opacity")
         logscale_attr = mesh.attributes.get("logscale")
         sh0_attr = mesh.attributes.get("sh0")
-        sh_attrs = [mesh.attributes.get(f"sh{j+1}") for j in range(15)]
+        sh_attrs = [mesh.attributes.get(f"sh{j + 1}") for j in range(15)]
         rot_quatxyz_attr = mesh.attributes.get("quatxyz")
         rot_quatw_attr = mesh.attributes.get("quatw")
 
@@ -1078,8 +1122,8 @@ class ExportGaussianSplatting(bpy.types.Operator):
 
             f_dc[i] = sh0_attr.data[i].vector.to_tuple()
             for j in range(15):
-                f_rest[i, j:j+45:15] = sh_attrs[j].data[i].vector.to_tuple()
-            
+                f_rest[i, j:j + 45:15] = sh_attrs[j].data[i].vector.to_tuple()
+
             rotxyz_quat = rot_quatxyz_attr.data[i].vector.to_tuple()
             rotw_quat = rot_quatw_attr.data[i].value
             rotation[i] = (*rotxyz_quat, rotw_quat)
@@ -1098,9 +1142,9 @@ class ExportGaussianSplatting(bpy.types.Operator):
         elements[:] = list(map(tuple, attributes))
         el = PlyElement.describe(elements, 'vertex')
         PlyData([el]).write(self.filepath)
-        
+
         return {'FINISHED'}
-    
+
     def invoke(self, context, event):
         if not self.filepath:
             self.filepath = bpy.path.abspath("//point_cloud.ply")
@@ -1110,7 +1154,6 @@ class ExportGaussianSplatting(bpy.types.Operator):
 
 
 class GaussianSplattingPanel(bpy.types.Panel):
-    
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
 
@@ -1127,18 +1170,29 @@ class GaussianSplattingPanel(bpy.types.Panel):
         row.operator(ImportGaussianSplatting.bl_idname, text="Import Gaussian Splatting")
 
         if obj is not None and "gaussian_splatting" in obj:
-            
+
             # Display Options
             row = layout.row()
-            row.prop(obj.modifiers["GeometryNodes"].node_group.nodes.get("Boolean"), "boolean", text="As point cloud (faster)")
+            row.prop(obj.modifiers["Geometry Nodes"].node_group.nodes.get("Boolean"), "boolean",
+                     text="As point cloud (faster)")
 
-            if not obj.modifiers["GeometryNodes"].node_group.nodes.get("Boolean").boolean:
+            row = layout.row()
+            row.prop(obj.modifiers["Geometry Nodes"].node_group.nodes.get("Value").outputs[0], "default_value",
+                     text="Opacity threshold")
+
+            if not obj.modifiers["Geometry Nodes"].node_group.nodes.get("Boolean").boolean:
                 row = layout.row()
-                row.prop(obj.modifiers["GeometryNodes"].node_group.nodes.get("Random Value").inputs["Probability"], "default_value", text="Display Percentage")
+                row.prop(obj.modifiers["Geometry Nodes"].node_group.nodes.get("Random Value").inputs["Probability"],
+                         "default_value", text="Display Percentage")
+
+            # Select active operator
+            row = layout.row()
+            row.operator()
 
             # Export Gaussian Splatting button
             row = layout.row()
             row.operator(ExportGaussianSplatting.bl_idname, text="Export Gaussian Splatting")
+
 
 def register():
     bpy.utils.register_class(ImportGaussianSplatting)
@@ -1147,12 +1201,14 @@ def register():
 
     bpy.types.Scene.ply_file_path = bpy.props.StringProperty(name="PLY Filepath", subtype='FILE_PATH')
 
+
 def unregister():
     bpy.utils.unregister_class(ImportGaussianSplatting)
     bpy.utils.unregister_class(GaussianSplattingPanel)
     bpy.utils.unregister_class(ExportGaussianSplatting)
 
     del bpy.types.Scene.ply_file_path
+
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
This PR is built on top of https://github.com/ReshotAI/gaussian-splatting-blender-addon/pull/17.

Added functionality:
- filter splats based on the specified float attribute during rendering (geometry nodes injection)
- ability to select active splats in edit mode for further processing (selection is recomputed from attribute data and user input. display percentage is not used)

Changes to Geometry Nodes (rearranged manually, programmatically it's still a mess:)):
<img width="479" alt="image" src="https://github.com/ReshotAI/gaussian-splatting-blender-addon/assets/61463055/c777f23d-32f5-45de-a4af-a71da3e57d76">
Changes to UI:
<img width="215" alt="image" src="https://github.com/ReshotAI/gaussian-splatting-blender-addon/assets/61463055/e7387ea4-d842-4e38-a8b9-1332b8e94a37">

Vector attributes support can be added but requires a separate "if" branch