### PR TITLE
Apply transform, multiple scenes support

### DIFF
--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -1132,7 +1132,7 @@ class ExportGaussianSplatting(bpy.types.Operator):
 
             rotxyz_quat = rot_quatxyz_attr.data[i].vector.to_tuple()
             rotw_quat = rot_quatw_attr.data[i].value
-            rotation[i] = (*rotxyz_quat, rotw_quat)
+            rotation[i] = (rotw_quat, *rotxyz_quat)
 
             # euler = mathutils.Euler(rot_euler_attr.data[i].vector)
             # quat = euler.to_quaternion()


### PR DESCRIPTION
Changes:
- Quaternion data bug fix
- Added section in apply transform to support GS, makes Join and Export Scene possible
<img width="311" alt="image" src="https://github.com/ReshotAI/gaussian-splatting-blender-addon/assets/61463055/e88b954b-f3c2-4f42-8082-d278759c74ee">  

- fixes for my last PR to support  multiple scenes

Thoughts: 
- might want to add apply transform to export operator logic by default
- Apply rotation currently does not alter SH values, though i think it should

**Would appreciate your testing/opinion, thanks!**