### PR TITLE
add blender_manifest.toml

### DIFF
--- a/blender-addon/blender_manifest.toml
+++ b/blender-addon/blender_manifest.toml
@@ -1,0 +1,18 @@
+schema_version = "1.0.0"
+
+id = "gaussian_splatting_io"
+version = "0.0.1"
+name = "3D Gaussian Splatting"
+tagline = "3D Gaussian Splatting tool"
+maintainer = "Alexandre Carlier <alexandre.carlier01@gmail.com>"
+type="add-on"
+
+blender_version_min = "4.2.0"
+
+tags = ["Import-Export"]
+license = [
+  "SPDX:GPL-3.0-or-later",
+]
+
+[permissions]
+files = "Import/export PLY from/to disk"


### PR DESCRIPTION
This adds a file that newer versions of Blender expect for blender add-ons. 

This also makes it possible to upload this add-on to the https://extensions.blender.org/ platform, which I highly recommend for visibility and ease of access for users.

Keep in mind that if you do intend to upload it there, you may _have to_ accept one of the licenses mentioned here: https://docs.blender.org/manual/en/latest/advanced/extensions/licenses.html.

I wrote SPDX:GPL-3.0-or-later because it's the default but it can be changed to whatever license fits your needs.